### PR TITLE
Fix docstring formatting for Sphinx compatibility

### DIFF
--- a/amaranth_soc/csr/reg.py
+++ b/amaranth_soc/csr/reg.py
@@ -420,8 +420,9 @@ class Register(wiring.Component):
     Arguments
     ---------
     fields : :class:`dict` or :class:`list` or :class:`Field`, optional
-        Collection of register fields. If omitted, a dict is populated from Python :term:`variable
-        annotations <python:variable annotation>`. ``fields`` is used to create
+        Collection of register fields. If omitted, a dict is populated from Python
+        `variable annotations <https://docs.python.org/3/glossary.html#term-variable-annotation>`_.
+        ``fields`` is used to create
         a :class:`FieldActionMap`, :class:`FieldActionArray`, or :class:`FieldAction`,
         depending on its type (:class:`dict`, :class:`list`, or :class:`Field`).
     access : :class:`~.csr.bus.Element.Access`
@@ -435,8 +436,9 @@ class Register(wiring.Component):
     Raises
     ------
     :exc:`ValueError`
-        If ``fields`` is not ``None`` and at least one :term:`variable annotation <python:variable
-        annotation>` is a :class:`Field`.
+        If ``fields`` is not ``None`` and at least one
+        `variable annotation <https://docs.python.org/3/glossary.html#term-variable-annotation>`_
+        is a :class:`Field`.
     :exc:`ValueError`
         If ``element.access`` is not readable and at least one field is readable.
     :exc:`ValueError`

--- a/amaranth_soc/memory.py
+++ b/amaranth_soc/memory.py
@@ -372,9 +372,10 @@ class MemoryMap:
             Name of the resource. It must not conflict with the name of other resources or windows
             present in this memory map.
         addr : :class:`int`
-            Address of the resource. Optional. If ``None``, the :ref:`implicit next address
-            <memory-implicit-next-address>` will be used. Otherwise, the exact specified address
-            (which must be a multiple of ``2 ** max(alignment, self.alignment)``) will be used.
+            Address of the resource. Optional. If ``None``, the
+            :ref:`implicit next address <memory-implicit-next-address>` will be used.
+            Otherwise, the exact specified address (which must be a multiple of
+            ``2 ** max(alignment, self.alignment)``) will be used.
         size : :class:`int`
             Size of the resource, in minimal addressable units. Rounded up to a multiple of
             ``2 ** max(alignment, self.alignment)``.
@@ -469,10 +470,10 @@ class MemoryMap:
             Name of the window. Optional. It must not conflict with the name of other resources or
             windows present in this memory map.
         addr : :class:`int`
-            Address of the window. Optional. If ``None``, the :ref:`implicit next address
-            <memory-implicit-next-address>` will be used after aligning it to
-            ``2 ** window.addr_width``. Otherwise, the exact specified address (which must be a
-            multiple of ``2 ** window.addr_width``) will be used.
+            Address of the window. Optional. If ``None``, the
+            :ref:`implicit next address <memory-implicit-next-address>` will be used
+            after aligning it to ``2 ** window.addr_width``. Otherwise, the exact specified
+            address (which must be a multiple of ``2 ** window.addr_width``) will be used.
         sparse : :class:`bool`
             Address translation type. Optional. Ignored if the datapath widths of both memory maps
             are equal; must be specified otherwise.


### PR DESCRIPTION
## Summary
- Replace `:term:` glossary references with external links to Python docs (the Python glossary isn't available when building docs with sphinx-autoapi)
- Reformat multi-line `:ref:` cross-references to avoid RST parsing issues with inline literals spanning multiple lines

## Test plan
- Build chipflow-docs with warning suppression disabled and verify these warnings are resolved:
  - `csr/reg.py:Register:3: term not in glossary: 'python:variable annotations'`
  - `memory.py:add_resource: Inline literal start-string without end-string`
  - `memory.py:add_window: Inline literal start-string without end-string`

🤖 Generated with [Claude Code](https://claude.com/claude-code)